### PR TITLE
Replace deprecated exists methods

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,0 +1,29 @@
+name: Build and Push Gem
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby 2.7
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+
+    - name: Publish to Github Package Registry
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+      env:
+        GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
+        OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/gem-version-check.yml
+++ b/.github/workflows/gem-version-check.yml
@@ -1,0 +1,17 @@
+name: Verify Gem Version Change
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Version Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Version Forget Me Not
+      uses: simplybusiness/version-forget-me-not@v2
+      env:
+        ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION_FILE_PATH: "non-stupid-digest-assets.gemspec"

--- a/lib/non-stupid-digest-assets.rb
+++ b/lib/non-stupid-digest-assets.rb
@@ -30,13 +30,13 @@ module NonStupidDigestAssets
         full_non_digest_path = File.join dir, logical_path
         full_non_digest_gz_path = "#{full_non_digest_path}.gz"
 
-        if File.exists? full_digest_path
+        if File.exist? full_digest_path
           logger.debug "Writing #{full_non_digest_path}"
           FileUtils.copy_file full_digest_path, full_non_digest_path, :preserve_attributes
         else
           logger.debug "Could not find: #{full_digest_path}"
         end
-        if File.exists? full_digest_gz_path
+        if File.exist? full_digest_gz_path
           logger.debug "Writing #{full_non_digest_gz_path}"
           FileUtils.copy_file full_digest_gz_path, full_non_digest_gz_path, :preserve_attributes
         else

--- a/non-stupid-digest-assets.gemspec
+++ b/non-stupid-digest-assets.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "non-stupid-digest-assets"
-  s.version     = "1.0.9"
+  s.version     = "1.0.10"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Alex Speller"]
   s.email       = ["alex@alexspeller.com"]


### PR DESCRIPTION
Due to the deprecation of the `exists?` methods for the File and Dir classes in ruby 2.1, and eventual removal in ruby 3.2, this pull request replaces the calls to these methods with the "bare verb" `exist?` method.

[See Ruby 3.2 removals in the changelog.](https://rubyreferences.github.io/rubychanges/3.2.html#removals)